### PR TITLE
Adding simple example of mathjax in the example article

### DIFF
--- a/_sections/04-results.md
+++ b/_sections/04-results.md
@@ -2,3 +2,7 @@
 title: Results
 ---
 The results of the experiment.
+
+You can also include mathematical equations like this: \(2+2=4\) or like this:
+
+\[e=mc^2\]

--- a/_sections/04-results.md
+++ b/_sections/04-results.md
@@ -2,3 +2,7 @@
 title: Results
 ---
 The results of the experiment.
+
+You can also include mathematical equations like this: \\(2+2=4\\) or like this:
+
+\\[e=mc^2\\]


### PR DESCRIPTION
Note that mathjax sometimes needs the usual LaTeX delimiters to be escaped. This is the case here.

You can see a rendered version of this pull request here: http://vincent-knight.com/paper-now/

Also, this would imply that the [wiki](https://github.com/PeerJ/paper-now/wiki/Text-Formatting) needs to be updated but I'll wait to see if you are happy with this PR to do that.

Love the look of this by the way :+1: Hoping to make use of it :speedboat: 
