### PR TITLE
use 32x32 px ORCID logo to look sharper on retina screens

### DIFF
--- a/index.json
+++ b/index.json
@@ -8,7 +8,7 @@ layout: null
 {% capture import_component %}{{ site.import }}research-article.html{% endcapture %}
 {
     "require": [
-        "https://orcid.org/sites/default/files/images/orcid_16x16.png",
+        "https://orcid.org/sites/default/files/images/orcid_32x32.png",
         {{ import_component | jsonify }}
     ],
     "article": {{ article | jsonify }},


### PR DESCRIPTION
Not sure if this is needed (couldn't figure out how the require of the orchid logo ties in to it all), but opening this PR to match PeerJ/paper-themes#1
